### PR TITLE
Add early error handling to simplify debugging

### DIFF
--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .trias_client import client as trias
-from .trias_client.exceptions import ApiError, InvalidLocationName
+from .trias_client.exceptions import ApiError, InvalidLocationName, HttpError
 
 
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -84,6 +84,10 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
                 continue
             except InvalidLocationName as error:
                 _LOGGER.error("Could not request data for %s reason %s", stop_id, error)
+                stop_dict["ok"] = False
+                continue
+            except HttpError as error:
+                _LOGGER.error(f"Http error {error.status_code}:\n{error.response}")
                 stop_dict["ok"] = False
                 continue
 
@@ -211,7 +215,6 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
                     "exception": True,
                 }
             else:
-
                 data = {}
                 if departures[0]["EstimatedTime"]:
                     data["next_departure"] = departures[0]["EstimatedTime"]

--- a/custom_components/trias/trias_client/client.py
+++ b/custom_components/trias/trias_client/client.py
@@ -62,6 +62,9 @@ class Client:
 
         req.encoding = "utf-8"
 
+        if req.status_code != 200:
+            raise exceptions.HttpError(req.status_code, req.text)
+
         response = req.text
         response_dict = trias_payload = xmltodict.parse(response)
 
@@ -320,7 +323,6 @@ class Client:
             )
 
             if stop_event["StopEvent"]["Service"]["Mode"]["PtMode"] == "rail":
-
                 data["PlannedBay"] = (
                     stop_event["StopEvent"]["ThisCall"]["CallAtStop"]
                     .get("PlannedBay", {})

--- a/custom_components/trias/trias_client/exceptions.py
+++ b/custom_components/trias/trias_client/exceptions.py
@@ -16,3 +16,10 @@ class ApiError(Exception):
 
 class InvalidLocationName(Exception):
     pass
+
+
+class HttpError(Exception):
+    def __init__(self, status_code, response, *args: object) -> None:
+        super().__init__(*args)
+        self.status_code = status_code
+        self.response = response


### PR DESCRIPTION
Hello, thanks for doing all the work :-)
I was just trying to set this up for me. Currently it's failing with some error.
To easier detect the error, i added the proposed change.

Btw. Do you know, what might be the problem here?
```
2024-11-04 23:14:04.121 DEBUG (SyncWorker_2) [custom_components.trias.trias_client.client] Received: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>502 Proxy Error</title>
</head><body>
<h1>Proxy Error</h1>
<p>The proxy server received an invalid
response from an upstream server.<br />
The proxy server could not handle the request<p>Reason: <strong>Error reading from remote server</strong></p></p>
</body></html>
```