### PR TITLE
Use HTTP Bearer Authorization when encountering HTTP 401.

### DIFF
--- a/custom_components/trias/config_flow.py
+++ b/custom_components/trias/config_flow.py
@@ -87,7 +87,7 @@ OPTIONS_MENU = {"stops": "Stops", "trips": "Trips"}
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle the option flow for WebUntis."""
+    """Handle the option flow for the Trias integration."""
 
     def __init__(self) -> None:
         """Initialize options flow."""

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -148,6 +148,11 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.info("Updated stop infos: \n%s", stop_id_dict)
             self.hass.config_entries.async_update_entry(self._entry, options=options)
 
+        if self._auth_method != self.client.auth_method:
+            options = {**self._config}
+            options["auth_method"] = self.client.auth_method
+            self.hass.config_entries.async_update_entry(self._entry, options=options)
+
         for trip_name, locations in self.trip_list.items():
             trip_id = trip_name.lower().replace(" ", "-")
 

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .trias_client.async_client import AsyncTriasClient
 from .trias_client.exceptions import ApiError, InvalidLocationName, HttpError
 from homeassistant.exceptions import ConfigEntryNotReady
+from .trias_client.async_client import AuthMethod
 
 from .const import DEFAULT_DEPARTURE_LIMIT
 
@@ -50,6 +51,7 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._url: str = entry.data["url"]
         self._api_key: str = entry.data.get("api_key", "")
+        self._auth_method: AuthMethod = AuthMethod(entry.options.get("auth_method", AuthMethod.REQUEST.value))
 
         # Async Client wird später erstellt
         self.client: AsyncTriasClient | None = None
@@ -75,7 +77,10 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
             session = aiohttp.ClientSession()
 
             self.client = AsyncTriasClient(
-                api_key=self._api_key, url=self._url, session=session
+                api_key=self._api_key,
+                url=self._url,
+                session=session,
+                auth_method=self._auth_method,
             )
 
     async def setup(self) -> bool:

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -51,7 +51,9 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._url: str = entry.data["url"]
         self._api_key: str = entry.data.get("api_key", "")
-        self._auth_method: AuthMethod = AuthMethod(entry.options.get("auth_method", AuthMethod.REQUEST.value))
+        self._auth_method: AuthMethod = AuthMethod(
+            entry.options.get("auth_method", AuthMethod.REQUEST.value)
+        )
 
         # Async Client wird später erstellt
         self.client: AsyncTriasClient | None = None

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -13,10 +13,9 @@ from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .trias_client.async_client import AsyncTriasClient
+from .trias_client.async_client import AsyncTriasClient, AuthMethod
 from .trias_client.exceptions import ApiError, InvalidLocationName, HttpError
 from homeassistant.exceptions import ConfigEntryNotReady
-from .trias_client.async_client import AuthMethod
 
 from .const import DEFAULT_DEPARTURE_LIMIT
 

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -50,9 +50,12 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._url: str = entry.data["url"]
         self._api_key: str = entry.data.get("api_key", "")
-        self._auth_method: AuthMethod = AuthMethod(
-            entry.options.get("auth_method", AuthMethod.REQUEST.value)
-        )
+        try:
+            self._auth_method: AuthMethod = AuthMethod(
+                entry.options.get("auth_method", AuthMethod.REQUEST.value)
+            )
+        except ValueError:
+            self._auth_method = AuthMethod.REQUEST
 
         # Async Client wird später erstellt
         self.client: AsyncTriasClient | None = None

--- a/custom_components/trias/coordinator.py
+++ b/custom_components/trias/coordinator.py
@@ -150,7 +150,7 @@ class TriasDataUpdateCoordinator(DataUpdateCoordinator):
             self.hass.config_entries.async_update_entry(self._entry, options=options)
 
         if self._auth_method != self.client.auth_method:
-            options = {**self._config}
+            options = dict(self._entry.options)
             options["auth_method"] = self.client.auth_method
             self.hass.config_entries.async_update_entry(self._entry, options=options)
 

--- a/custom_components/trias/trias_client/async_client.py
+++ b/custom_components/trias/trias_client/async_client.py
@@ -19,9 +19,11 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class AuthMethod(StrEnum):
     REQUEST = "request"
     BEARER = "bearer"
+
 
 class AsyncTriasClient:
     """Async client for Trias API."""
@@ -37,7 +39,7 @@ class AsyncTriasClient:
         self.url = url
         self._session = session
         self._timeout = 30
-        self._auth_method = auth_method
+        self.auth_method = auth_method
 
     async def ensure_session(self):
         """Ensure we have a session."""
@@ -75,7 +77,7 @@ class AsyncTriasClient:
 
         # If we know already that Bearer auth works, use it right away.
         # Otherwise, we'll try the standard method first and fall back to Bearer if we get HTTP 401.
-        if self._auth_method == AuthMethod.BEARER:
+        if self.auth_method == AuthMethod.BEARER:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
         try:
@@ -83,12 +85,14 @@ class AsyncTriasClient:
                 async with self._session.post(
                     self.url, data=xml.encode("utf-8"), headers=headers
                 ) as response:
-
                     response_text = ""
 
                     # When encountering HTTP 401 and we haven't tried bearer auth yet,
                     # retry with HTTP Bearer authentication
-                    if response.status == 401 and not self._auth_method == AuthMethod.Bearer:
+                    if (
+                        response.status == 401
+                        and not self.auth_method == AuthMethod.BEARER
+                    ):
                         _LOGGER.warning(
                             "Received HTTP 401 (Unauthorized). Retrying with Bearer token authentication."
                         )
@@ -99,7 +103,7 @@ class AsyncTriasClient:
                             if auth_response.status == 200:
                                 # Bearer auth succeeded, save this for future requests
                                 response_text = await auth_response.text()
-                                self._auth_method = AuthMethod.BEARER
+                                self.auth_method = AuthMethod.BEARER
                             else:
                                 raise exceptions.HttpError(
                                     auth_response.status, await auth_response.text()

--- a/custom_components/trias/trias_client/async_client.py
+++ b/custom_components/trias/trias_client/async_client.py
@@ -1,5 +1,7 @@
 """Async client for Trias API."""
 
+from enum import StrEnum
+
 import aiohttp
 import async_timeout
 import xmltodict
@@ -17,15 +19,25 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+class AuthMethod(StrEnum):
+    REQUEST = "request"
+    BEARER = "bearer"
 
 class AsyncTriasClient:
     """Async client for Trias API."""
 
-    def __init__(self, api_key: str, url: str, session: aiohttp.ClientSession = None):
+    def __init__(
+        self,
+        api_key: str,
+        url: str,
+        session: aiohttp.ClientSession = None,
+        auth_method: AuthMethod = AuthMethod.REQUEST,
+    ):
         self.api_key = api_key
         self.url = url
         self._session = session
         self._timeout = 30
+        self._auth_method = auth_method
 
     async def ensure_session(self):
         """Ensure we have a session."""

--- a/custom_components/trias/trias_client/async_client.py
+++ b/custom_components/trias/trias_client/async_client.py
@@ -73,6 +73,11 @@ class AsyncTriasClient:
             "User-Agent": "HomeAssistant/Trias-Integration",
         }
 
+        # If we know already that Bearer auth works, use it right away.
+        # Otherwise, we'll try the standard method first and fall back to Bearer if we get HTTP 401.
+        if self._auth_method == AuthMethod.BEARER:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
         try:
             async with async_timeout.timeout(self._timeout):
                 async with self._session.post(

--- a/custom_components/trias/trias_client/async_client.py
+++ b/custom_components/trias/trias_client/async_client.py
@@ -84,16 +84,36 @@ class AsyncTriasClient:
                     self.url, data=xml.encode("utf-8"), headers=headers
                 ) as response:
 
-                    if response.status == 400:
+                    response_text = ""
+
+                    # When encountering HTTP 401 and we haven't tried bearer auth yet,
+                    # retry with HTTP Bearer authentication
+                    if response.status == 401 and not self._auth_method == AuthMethod.Bearer:
+                        _LOGGER.warning(
+                            "Received HTTP 401 (Unauthorized). Retrying with Bearer token authentication."
+                        )
+                        headers["Authorization"] = f"Bearer {self.api_key}"
+                        async with self._session.post(
+                            self.url, data=xml.encode("utf-8"), headers=headers
+                        ) as auth_response:
+                            if auth_response.status == 200:
+                                # Bearer auth succeeded, save this for future requests
+                                response_text = await auth_response.text()
+                                self._auth_method = AuthMethod.BEARER
+                            else:
+                                raise exceptions.HttpError(
+                                    auth_response.status, await auth_response.text()
+                                )
+                    elif response.status == 400:
                         raise exceptions.InvalidRequest
-                    if response.status == 403:
+                    elif response.status == 403:
                         raise exceptions.InvalidApiKey
-                    if response.status != 200:
+                    elif response.status != 200:
                         raise exceptions.HttpError(
                             response.status, await response.text()
                         )
-
-                    response_text = await response.text()
+                    else:
+                        response_text = await response.text()
 
                     # Parse response
                     response_dict = xmltodict.parse(response_text)

--- a/custom_components/trias/trias_client/client.py
+++ b/custom_components/trias/trias_client/client.py
@@ -69,13 +69,31 @@ class Client:
 
         req.encoding = "utf-8"
 
-        if req.status_code == 400:
+        # When encountering HTTP 401 and we haven't tried bearer auth yet,
+        # retry with HTTP Bearer authentication
+        if req.status_code == 401:
+            _LOGGER.warning(
+                "Received HTTP 401 (Unauthorized). Retrying with Bearer token authentication."
+            )
+            headers["Authorization"] = f"Bearer {self.api_key}"
+            auth_req = requests.request(
+                "post",
+                self.url,
+                data=xml.encode("utf-8"),
+                headers=headers,
+                timeout=20,
+            )
+            auth_req.encoding = "utf-8"
+            if auth_req.status_code == 200:
+                # Bearer auth succeeded, save this for future requests
+                req = auth_req
+            else:
+                raise exceptions.HttpError(auth_req.status_code, auth_req.text)
+        elif req.status_code == 400:
             raise exceptions.InvalidRequest
-
-        if req.status_code == 403:
+        elif req.status_code == 403:
             raise exceptions.InvalidApiKey
-
-        if req.status_code != 200:
+        elif req.status_code != 200:
             raise exceptions.HttpError(req.status_code, req.text)
 
         response = req.text

--- a/custom_components/trias/trias_client/client.py
+++ b/custom_components/trias/trias_client/client.py
@@ -281,7 +281,13 @@ class Client:
         xml = xml.replace("NumberOfResults__", str(number_of_results))
         xml = xml.replace("IncludePtModes__", str(include_pt_podes).lower())
 
-        result = self.get(xml)
+        result = None
+        try:
+            result = self.get(xml)
+        except exceptions.ApiError:
+            number_of_results = 0
+            result = {"LocationInformationResponse": {}}
+            pass
 
         error = None
         try:

--- a/custom_components/trias/trias_client/client.py
+++ b/custom_components/trias/trias_client/client.py
@@ -129,7 +129,10 @@ class Client:
 
     def test_connection(self) -> bool:
         """Simple check if API key + URL work"""
-        self.location_information_request("e", ignore_low_probability=True)
+        try:
+            self.location_information_request("e", ignore_low_probability=True)
+        except exceptions.ApiError:
+            pass
         return True
 
     def stop_event_request(
@@ -281,13 +284,7 @@ class Client:
         xml = xml.replace("NumberOfResults__", str(number_of_results))
         xml = xml.replace("IncludePtModes__", str(include_pt_podes).lower())
 
-        result = None
-        try:
-            result = self.get(xml)
-        except exceptions.ApiError:
-            number_of_results = 0
-            result = {"LocationInformationResponse": {}}
-            pass
+        result = self.get(xml)
 
         error = None
         try:

--- a/custom_components/trias/trias_client/client.py
+++ b/custom_components/trias/trias_client/client.py
@@ -85,7 +85,6 @@ class Client:
             )
             auth_req.encoding = "utf-8"
             if auth_req.status_code == 200:
-                # Bearer auth succeeded, save this for future requests
                 req = auth_req
             else:
                 raise exceptions.HttpError(auth_req.status_code, auth_req.text)


### PR DESCRIPTION
This pull request adds support for HTTP Bearer authorization.

After the change, when the code encounters a HTTP response code 401, HTTP Bearer authorization is attempted first, before ultimately accepting the failure. When the HTTP Bearer authorization scheme has worked, this is memorized in the options, so that further attempts directly use HTTP Bearer authorization.

The option update is **only performed during the integration setup** as to not interfere with existing installations and/or temporary authorization failures.

This change is intended to fix issue #10.

I tested it with the VRN endpoint and went through several cases (valid/invalid api key). So far it works as intended.
